### PR TITLE
fix typo in setting up vs-code profile

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -125,7 +125,7 @@ echo "Setting up VS Code..."
 mkdir -p ~/Library/Application\ Support/Code/User
 if check_file '~/Library/Application Support/Code/User/settings.json'; then
   echo "Copying old settings.json into $OLD_DIR..."
-  cp ~/Library/Application\ Support/iTerm2/DynamicProfiles/settings.json $OLD_DIR/vscode.json
+  cp ~/Library/Application\ Support/Code/User/settings.json $OLD_DIR/vscode.json
 fi
 ln -sf $DOTFILES_DIR/vscode.json ~/Library/Application\ Support/Code/User/settings.json
 echo "...done"


### PR DESCRIPTION
Fixes little copy/pasta in the set-up script from the iterm profile when saving previous VS Code user profile if one exists.